### PR TITLE
Added support for macOS 10.12 keychain

### DIFF
--- a/iChainbreaker.py
+++ b/iChainbreaker.py
@@ -152,7 +152,13 @@ def main():
 
             unwrappedkey = AESUnwrap(key, wrappedkey)
 
-            decrypted = gcm_decrypt(unwrappedkey, "", encrypted_data, "", auth_tag)
+            # Security-57740.51.3/OSX/sec/securityd/SecDbKeychainItem.c:97
+            #
+            # // echo "keychainblobstaticiv" | openssl dgst -sha256 | cut -c1-24 | xargs -I {} echo "0x{}" | xxd -r | xxd -p  -i
+            # static const uint8_t gcmIV[kIVSizeAESGCM] = {
+            #     0x1e, 0xa0, 0x5c, 0xa9, 0x98, 0x2e, 0x87, 0xdc, 0xf1, 0x45, 0xe8, 0x24
+            # };
+            decrypted = gcm_decrypt(unwrappedkey, "\x1e\xa0\x5c\xa9\x98\x2e\x87\xdc\xf1\x45\xe8\x24", encrypted_data, data[:sizeof(_EncryptedBlobHeader)], auth_tag)
 
             if len(decrypted) is 0:
                 #print(" [-] Decryption Process Failed. Invalid Key or Data is corrupted.")


### PR DESCRIPTION
Previously to macOS 10.12, keychain items had an empty IV and no authenticated data. Now they have a static IV.

For more information see published source code of securityd:
Security-57740.51.3/OSX/sec/securityd/SecDbKeychainItem.c
  
  
It might be useful to detect whether an IV and authenticated data must be processed or not. The reported meta information of a macOS 10.12 keychain is:
```
[+] Keybag Header
 [-] versions : 4
 [-] type : System Keybag
```